### PR TITLE
Fix/yujin flow

### DIFF
--- a/src/components/Main/Guideline3.js
+++ b/src/components/Main/Guideline3.js
@@ -67,7 +67,7 @@ function Guideline3(props) {
       })
       .then((res) => {
         console.log(res);
-        window.open(`http://localhost:5000/apply/${data.id}/${step}`);
+        window.location.href=`http://localhost:5000/apply/${data.id}/${step}`;
       });
   };
 
@@ -95,7 +95,7 @@ function Guideline3(props) {
         {result[0].departmentList.map((data) => (
           // <button onClick={=>  window.open(`http://localhost:5000/apply/${data.id}/${result[0].stepDateDtos[0].step}`) } className='z-button' style={{ width: 'fit-content', marginLeft: '0', marginRight: '2%' }}>{ data. department }</button>
           <button
-            onClick={() => saveStatus(data, result[0].stepDateDtos[0].step)}
+            onClick={() => window.location.href=`http://localhost:5000/question/create/${params.party}`}
             className="z-button"
             style={{ width: 'fit-content', marginLeft: '0', marginRight: '2%' }}
           >

--- a/src/components/Main/Guideline3.js
+++ b/src/components/Main/Guideline3.js
@@ -59,7 +59,6 @@ function Guideline3(props) {
       step: 1,
       user: 0,
     };
-    console.log(body);
     const res = instance
       .post(`/apply/saveStatus`, body, {
         headers: {

--- a/src/components/Main/TopBar.js
+++ b/src/components/Main/TopBar.js
@@ -21,9 +21,7 @@ function TopBar(props) {
         return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
       }).join(''));
       setId((id) => jsonPayload);
-      // console.log("로긍니; ", jsonPayload);
     }
-    console.log('tf is ' + tf);
     setAuth(tf);
   }
 

--- a/src/components/OAuth.js
+++ b/src/components/OAuth.js
@@ -17,8 +17,8 @@ function Oauth() {
             window.localStorage.setItem('authorization', authorization);
             console.log(authorization);
             alert('로그인 완료');
-
-            navigate('/');
+            navigate('/main');
+            window.location.reload();
           });
       } catch (e) {
         console.log(e);

--- a/src/components/PartyListForStaff/PartyList.js
+++ b/src/components/PartyListForStaff/PartyList.js
@@ -1,11 +1,12 @@
-import React from 'react';
+import React, { useState, useEffect, useParams } from 'react';
 
 import '../../assets/PartyListForStaff/PartyList.css';
 
 function PartyList(props) {
 
+  // 고쳐야 하는 부분 (링크 수정)
   const departmentClick = async (data, e) => {
-    window.location.href = `http://localhost:5000/apply/forStaff/${ data.deId }/${ data.stepId }`;
+    window.location.href = `http://localhost:5000/party/informs/${props.partyId}`;
   }
 
   return (
@@ -13,7 +14,7 @@ function PartyList(props) {
       <button className={ props.isOddNum } style={{ height: '55px', borderRadius: '10px' }}
         onClick={ (e) => {departmentClick( { deId: props.departmentId, stepId: props.stepId },  e)}}>
         <div>
-        <p className='z-party-p' style={{ color: 'black', lineHeight: '350%' }}>{ props.partyId }</p>
+        <p className='z-party-p' style={{ color: 'black', lineHeight: '350%' }}>{ props.partyId.split('-')[0] } { props.partyId.split('-')[1] }기</p>
         <p className='z-role-p' style={{ lineHeight: '380%' }}>{ props.role }</p>
         </div>
       </button>

--- a/src/components/PartyListForStaff/PartyList.js
+++ b/src/components/PartyListForStaff/PartyList.js
@@ -4,7 +4,6 @@ import '../../assets/PartyListForStaff/PartyList.css';
 
 function PartyList(props) {
 
-  // 고쳐야 하는 부분 (링크 수정)
   const departmentClick = async (data, e) => {
     window.location.href = `http://localhost:5000/party/informs/${props.partyId}`;
   }
@@ -14,7 +13,7 @@ function PartyList(props) {
       <button className={ props.isOddNum } style={{ height: '55px', borderRadius: '10px' }}
         onClick={ (e) => {departmentClick( { deId: props.departmentId, stepId: props.stepId },  e)}}>
         <div>
-        <p className='z-party-p' style={{ color: 'black', lineHeight: '350%' }}>{ props.partyId.split('-')[0] } { props.partyId.split('-')[1] }기</p>
+        <p className='z-party-p' style={{ color: 'black', lineHeight: '350%' }}>{ props.partyId }</p>
         <p className='z-role-p' style={{ lineHeight: '380%' }}>{ props.role }</p>
         </div>
       </button>

--- a/src/components/PartyListForStaff/PartyList.js
+++ b/src/components/PartyListForStaff/PartyList.js
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { useState, useEffect, useParams } from 'react';
 
 import '../../assets/PartyListForStaff/PartyList.css';
 
 function PartyList(props) {
 
   const departmentClick = async (data, e) => {
-    window.location.href = `http://localhost:5000/apply/forStaff/${ data.deId }/${ data.stepId }`;
+    window.location.href = `http://localhost:5000/party/informs/${props.partyId}`;
   }
 
   return (

--- a/src/pages/MainAuth.js
+++ b/src/pages/MainAuth.js
@@ -7,7 +7,6 @@ function MainAuth(auth, option) {
 
   if (option) {
     if (!authorization) {
-    //   navigate('/login');
       console.log('로그인 하세요');
       return false;
     } else {

--- a/src/pages/PartyInforms.js
+++ b/src/pages/PartyInforms.js
@@ -1,10 +1,55 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
+import instance from '../utils/axiosConfig';
+
 import '../assets/PartyEnroll/PartyCode.css';
 
-function PartyInformsPage() {
-  const params = useParams();
+function PartyInformsPage(props) {
+
+  let params = useParams();
+
   const partyId = params.party;
+  
+  const [department, setDepartment] = useState(null);
+  const [step, setStep] = useState(null);
+  const [error, setError] = useState(false);
+
+  const getDepartment = async () => {
+   try {
+     setDepartment(null);
+     console.log(params.party);
+     const res = await instance.get(`/department/common/${params.party}`, {
+       headers: {
+       },
+     });
+     setDepartment(res.data.id);
+     console.log(res.data);
+   } catch (e) {
+       setError(e);
+   }
+  };
+
+  const getStep = async () => {
+   try {
+     setStep(null);
+     const res = await instance.get(`/recruit/step/first/${params.party}`, {
+       headers: {
+       },
+     });
+     setStep(res.data.id);
+   } catch (e) {
+       setError(e);
+   }
+  };
+
+  useEffect(() => {
+    getDepartment();
+    getStep();
+  }, []);
+
+  const applyStatus = () => {
+    window.location.href = `/apply/forStaff/${department}/${step}`;
+  }
 
   return (
     <div class="J_wrap_div">
@@ -17,9 +62,7 @@ function PartyInformsPage() {
           class="J_partyInforms_btn J_copy_btton"
           style={{ 'margin-bottom': 60 }}
           id="J_copy_btton"
-          // onClick={() => (window.location.href = '/apply/forStaff/1/1')}
-          onClick={() => alert('지원서 등록을 먼저 해주세요')}
-        >
+          onClick={() => (window.location.href = `/apply/forStaff/${department}/${step}`)} >
           모집 현황 확인하기
         </button>
         <button
@@ -46,7 +89,7 @@ function PartyInformsPage() {
         <button
           class="J_partyInforms_btn J_copy_btton"
           id="J_copy_btton"
-          onClick={() => (window.location.href = `/grading/standard/read/${partyId}/1`)}
+          onClick={() => (window.location.href = `/grading/standard/read/${partyId}/${step}`)}
         >
           채점 기준 확인/등록하기
         </button>

--- a/src/pages/PartyInforms.js
+++ b/src/pages/PartyInforms.js
@@ -1,10 +1,76 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
+import instance from '../utils/axiosConfig';
+
 import '../assets/PartyEnroll/PartyCode.css';
 
-function PartyInformsPage() {
-  const params = useParams();
+function PartyInformsPage(props) {
+
+  let params = useParams();
+
+<<<<<<< Updated upstream
+  const partyId = encodeURI(encodeURIComponent(params.party));
+=======
   const partyId = params.party;
+>>>>>>> Stashed changes
+  
+  const [department, setDepartment] = useState(null);
+  const [step, setStep] = useState(null);
+  const [error, setError] = useState(false);
+
+  const getDepartment = async () => {
+   try {
+     setDepartment(null);
+     console.log(params.party);
+<<<<<<< Updated upstream
+     const res = await instance.get('/department/' + '포합-1', {
+       headers: {
+       },
+     });
+     setDepartment(res.data);
+     console.log('department is ', res);
+=======
+     const res = await instance.get(`/department/common/${params.party}`, {
+       headers: {
+       },
+     });
+     setDepartment(res.data.id);
+     console.log(res.data);
+>>>>>>> Stashed changes
+   } catch (e) {
+       setError(e);
+   }
+  };
+
+  const getStep = async () => {
+   try {
+     setStep(null);
+     const res = await instance.get(`/recruit/step/first/${params.party}`, {
+       headers: {
+       },
+     });
+<<<<<<< Updated upstream
+     setStep(res.data);
+     console.log('step is ', res);
+=======
+     setStep(res.data.id);
+>>>>>>> Stashed changes
+   } catch (e) {
+       setError(e);
+   }
+  };
+
+  useEffect(() => {
+    getDepartment();
+    getStep();
+  }, []);
+<<<<<<< Updated upstream
+=======
+
+  const applyStatus = () => {
+    window.location.href = `/apply/forStaff/${department}/${step}`;
+  }
+>>>>>>> Stashed changes
 
   return (
     <div class="J_wrap_div">
@@ -17,9 +83,7 @@ function PartyInformsPage() {
           class="J_partyInforms_btn J_copy_btton"
           style={{ 'margin-bottom': 60 }}
           id="J_copy_btton"
-          // onClick={() => (window.location.href = '/apply/forStaff/1/1')}
-          onClick={() => alert('지원서 등록을 먼저 해주세요')}
-        >
+          onClick={() => (window.location.href = `/apply/forStaff/${department}/${step}`)} >
           모집 현황 확인하기
         </button>
         <button
@@ -46,7 +110,7 @@ function PartyInformsPage() {
         <button
           class="J_partyInforms_btn J_copy_btton"
           id="J_copy_btton"
-          onClick={() => (window.location.href = `/grading/standard/read/${partyId}/1`)}
+          onClick={() => (window.location.href = `/grading/standard/read/${partyId}/${step}`)}
         >
           채점 기준 확인/등록하기
         </button>

--- a/src/pages/PartyInforms.js
+++ b/src/pages/PartyInforms.js
@@ -8,11 +8,15 @@ function PartyInformsPage(props) {
 
   let params = useParams();
 
+<<<<<<< HEAD
 <<<<<<< Updated upstream
   const partyId = encodeURI(encodeURIComponent(params.party));
 =======
   const partyId = params.party;
 >>>>>>> Stashed changes
+=======
+  const partyId = params.party;
+>>>>>>> fix/must_merge
   
   const [department, setDepartment] = useState(null);
   const [step, setStep] = useState(null);
@@ -22,6 +26,7 @@ function PartyInformsPage(props) {
    try {
      setDepartment(null);
      console.log(params.party);
+<<<<<<< HEAD
 <<<<<<< Updated upstream
      const res = await instance.get('/department/' + '포합-1', {
        headers: {
@@ -30,13 +35,18 @@ function PartyInformsPage(props) {
      setDepartment(res.data);
      console.log('department is ', res);
 =======
+=======
+>>>>>>> fix/must_merge
      const res = await instance.get(`/department/common/${params.party}`, {
        headers: {
        },
      });
      setDepartment(res.data.id);
      console.log(res.data);
+<<<<<<< HEAD
 >>>>>>> Stashed changes
+=======
+>>>>>>> fix/must_merge
    } catch (e) {
        setError(e);
    }
@@ -49,12 +59,16 @@ function PartyInformsPage(props) {
        headers: {
        },
      });
+<<<<<<< HEAD
 <<<<<<< Updated upstream
      setStep(res.data);
      console.log('step is ', res);
 =======
      setStep(res.data.id);
 >>>>>>> Stashed changes
+=======
+     setStep(res.data.id);
+>>>>>>> fix/must_merge
    } catch (e) {
        setError(e);
    }
@@ -64,13 +78,19 @@ function PartyInformsPage(props) {
     getDepartment();
     getStep();
   }, []);
+<<<<<<< HEAD
 <<<<<<< Updated upstream
 =======
+=======
+>>>>>>> fix/must_merge
 
   const applyStatus = () => {
     window.location.href = `/apply/forStaff/${department}/${step}`;
   }
+<<<<<<< HEAD
 >>>>>>> Stashed changes
+=======
+>>>>>>> fix/must_merge
 
   return (
     <div class="J_wrap_div">

--- a/src/pages/PartyInforms.js
+++ b/src/pages/PartyInforms.js
@@ -8,15 +8,7 @@ function PartyInformsPage(props) {
 
   let params = useParams();
 
-<<<<<<< HEAD
-<<<<<<< Updated upstream
-  const partyId = encodeURI(encodeURIComponent(params.party));
-=======
   const partyId = params.party;
->>>>>>> Stashed changes
-=======
-  const partyId = params.party;
->>>>>>> fix/must_merge
   
   const [department, setDepartment] = useState(null);
   const [step, setStep] = useState(null);
@@ -26,27 +18,12 @@ function PartyInformsPage(props) {
    try {
      setDepartment(null);
      console.log(params.party);
-<<<<<<< HEAD
-<<<<<<< Updated upstream
-     const res = await instance.get('/department/' + '포합-1', {
-       headers: {
-       },
-     });
-     setDepartment(res.data);
-     console.log('department is ', res);
-=======
-=======
->>>>>>> fix/must_merge
      const res = await instance.get(`/department/common/${params.party}`, {
        headers: {
        },
      });
      setDepartment(res.data.id);
      console.log(res.data);
-<<<<<<< HEAD
->>>>>>> Stashed changes
-=======
->>>>>>> fix/must_merge
    } catch (e) {
        setError(e);
    }
@@ -59,16 +36,7 @@ function PartyInformsPage(props) {
        headers: {
        },
      });
-<<<<<<< HEAD
-<<<<<<< Updated upstream
-     setStep(res.data);
-     console.log('step is ', res);
-=======
      setStep(res.data.id);
->>>>>>> Stashed changes
-=======
-     setStep(res.data.id);
->>>>>>> fix/must_merge
    } catch (e) {
        setError(e);
    }
@@ -78,19 +46,10 @@ function PartyInformsPage(props) {
     getDepartment();
     getStep();
   }, []);
-<<<<<<< HEAD
-<<<<<<< Updated upstream
-=======
-=======
->>>>>>> fix/must_merge
 
   const applyStatus = () => {
     window.location.href = `/apply/forStaff/${department}/${step}`;
   }
-<<<<<<< HEAD
->>>>>>> Stashed changes
-=======
->>>>>>> fix/must_merge
 
   return (
     <div class="J_wrap_div">
@@ -130,7 +89,7 @@ function PartyInformsPage(props) {
         <button
           class="J_partyInforms_btn J_copy_btton"
           id="J_copy_btton"
-          onClick={() => (window.location.href = `/grading/standard/read/${partyId}/${step}`)}
+          onClick={() => (window.location.href = `/grading/standard/read/${partyId}/1`)}
         >
           채점 기준 확인/등록하기
         </button>

--- a/src/pages/PartyListForStaff.js
+++ b/src/pages/PartyListForStaff.js
@@ -47,10 +47,14 @@ function PartyListForStaff() {
 
   return (
     <div style={{ marginTop: '50px' }}>
+      {/* <PartyList hashMap={data} isOddNum={odd+(key++%2)} /> */}
       {data.map(data => (
         <PartyList partyId={ data.partyId } departmentId={ data.departmentId } 
           stepId={ data.stepId } role={ data.role } isOddNum={odd+(key++%2)}/>
       ))}
+      {/* {data.map(data => (
+        <PartyList partyId={data.id} isOddNum={odd+(key++%2)} />
+      ))} */}
     </div>
   );
 }


### PR DESCRIPTION
카톡방에 보낸 거 봐봐방

- 카카오 로그인 시 리로드 -> 로그인 해주세요에서 마이페이지로 바로 바뀌도록
- 마이페이지에서 소속 버튼 클릭하면 소속 정보로 이동
- 소속 정보에서 모집 현황 클릭하면 모집 현황 페이지로 이동
- 대충 보기엔 다 잘 돼보이는데 지금 실눈 뜨고 있어서 믿을 수 없음